### PR TITLE
Fix #5631 - Can't build epmodel on MSVC (LNK1189) -  Split openstudiolib.dll into 4 separate DLLs on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,10 @@ if(MSVC)
   # warning level 3
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3")
 
+  # Remove unreferenced COMDATs (functions/data) before they reach the linker.
+  # Shrinks object files; does NOT reduce dllexport'd symbol counts (verified empirically).
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:inline")
+
   # warning level 4 - DLM: we should shoot for this
   #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1675,7 +1675,9 @@ if (MSVC)
     # within the same library. This may result in less efficient function calls.
 
     # The potential inefficiency goes away if we use LTO linking
-    target_link_libraries(openstudiolib PRIVATE -IGNORE:4217,4049)
+    foreach(_os_lib openstudiolib openstudiomodellib openstudioepmodellib openstudioutilitieslib)
+      target_link_libraries(${_os_lib} PRIVATE -IGNORE:4217,4049)
+    endforeach()
     if(CMAKE_SIZEOF_VOID_P EQUAL 8) # only applies to 64 bit windows platforms
       if (BUILD_RUBY_BINDINGS)
         target_link_libraries(openstudio_rb PRIVATE -IGNORE:4217,4049)

--- a/python/engine/CMakeLists.txt
+++ b/python/engine/CMakeLists.txt
@@ -71,7 +71,7 @@ if(BUILD_TESTING)
   set(pythonengine_test_depends
     openstudio_scriptengine
     openstudiolib
-    openstudio_epmodel
+    openstudio_epmodel_headers
     fmt::fmt
   )
 

--- a/ruby/engine/CMakeLists.txt
+++ b/ruby/engine/CMakeLists.txt
@@ -255,7 +255,7 @@ if(BUILD_TESTING)
   set(rubyengine_test_depends
     openstudio_scriptengine
     openstudiolib
-    openstudio_epmodel
+    openstudio_epmodel_headers
     fmt::fmt
   )
 

--- a/src/epmodel/CMakeLists.txt
+++ b/src/epmodel/CMakeLists.txt
@@ -2796,6 +2796,23 @@ set(${target_name}_depends
 set(${target_name}_depends ${${target_name}_depends} PARENT_SCOPE)
 
 target_compile_definitions(${target_name} PRIVATE openstudio_epmodel_EXPORTS SHARED_OS_LIBS)
+
+# Headers-only INTERFACE target: gives consumers epmodel's per-subfolder include
+# directories without pulling in its OBJECT library's actual object files. On MSVC,
+# openstudio_epmodel's objects already live in openstudioepmodellib.dll; any consumer
+# that links both openstudio_epmodel directly AND openstudiolib (which PUBLIC-links
+# openstudioepmodellib) gets the same symbols twice -- once as real definitions, once
+# as the DLL's import-lib thunks -- which MSVC rejects (LNK2005). Consumers that only
+# need to compile against epmodel headers (not embed its objects) should link this
+# instead of openstudio_epmodel.
+add_library(openstudio_epmodel_headers INTERFACE)
+target_include_directories(openstudio_epmodel_headers INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/HVACComponent
+  ${CMAKE_CURRENT_SOURCE_DIR}/ModelObject
+  ${CMAKE_CURRENT_SOURCE_DIR}/scaffolds
+  ${CMAKE_CURRENT_SOURCE_DIR}/StraightComponent
+  ${CMAKE_CURRENT_SOURCE_DIR}/ShadingMaterial)
+
 target_include_directories(${target_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/HVACComponent
   ${CMAKE_CURRENT_SOURCE_DIR}/ModelObject
   ${CMAKE_CURRENT_SOURCE_DIR}/scaffolds
@@ -3675,7 +3692,7 @@ set(${target_name}_test_src
 
 set(${target_name}_test_depends
   openstudiolib
-  openstudio_epmodel
+  openstudio_epmodel_headers
 )
 
 CREATE_SRC_GROUPS("${${target_name}_test_src}")

--- a/src/epmodel/CMakeLists.txt
+++ b/src/epmodel/CMakeLists.txt
@@ -2751,6 +2751,23 @@ set(${target_name}_depends
 set(${target_name}_depends ${${target_name}_depends} PARENT_SCOPE)
 
 target_compile_definitions(${target_name} PRIVATE openstudio_epmodel_EXPORTS SHARED_OS_LIBS)
+
+# Headers-only INTERFACE target: gives consumers epmodel's per-subfolder include
+# directories without pulling in its OBJECT library's actual object files. On MSVC,
+# openstudio_epmodel's objects already live in openstudioepmodellib.dll; any consumer
+# that links both openstudio_epmodel directly AND openstudiolib (which PUBLIC-links
+# openstudioepmodellib) gets the same symbols twice -- once as real definitions, once
+# as the DLL's import-lib thunks -- which MSVC rejects (LNK2005). Consumers that only
+# need to compile against epmodel headers (not embed its objects) should link this
+# instead of openstudio_epmodel.
+add_library(openstudio_epmodel_headers INTERFACE)
+target_include_directories(openstudio_epmodel_headers INTERFACE
+  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/HVACComponent
+  ${CMAKE_CURRENT_SOURCE_DIR}/ModelObject
+  ${CMAKE_CURRENT_SOURCE_DIR}/scaffolds
+  ${CMAKE_CURRENT_SOURCE_DIR}/StraightComponent
+  ${CMAKE_CURRENT_SOURCE_DIR}/ShadingMaterial)
+
 target_include_directories(${target_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/HVACComponent
   ${CMAKE_CURRENT_SOURCE_DIR}/ModelObject
   ${CMAKE_CURRENT_SOURCE_DIR}/scaffolds
@@ -3626,7 +3643,7 @@ set(${target_name}_test_src
 
 set(${target_name}_test_depends
   openstudiolib
-  openstudio_epmodel
+  openstudio_epmodel_headers
 )
 
 CREATE_SRC_GROUPS("${${target_name}_test_src}")

--- a/src/epmodel/EPModelSwig.cmake
+++ b/src/epmodel/EPModelSwig.cmake
@@ -159,7 +159,12 @@ macro(make_epmodel_swig_bindings NAME SIMPLENAME KEY_I_FILE I_FILES PARENT_TARGE
     target_include_directories(${python_target} PRIVATE ${common_swig_include_dirs})
     target_include_directories(${python_target} SYSTEM PRIVATE ${Python_INCLUDE_DIRS})
     target_compile_definitions(${python_target} PRIVATE SHARED_OS_LIBS SWIG_PYTHON_SILENT_MEMLEAK)
-    target_link_libraries(${python_target} PUBLIC ${PARENT_TARGET} ${${PARENT_TARGET}_depends})
+    # Do NOT link PARENT_TARGET (the openstudio_epmodel OBJECT library) directly here:
+    # every python binding target already gets the real symbols via openstudiolib
+    # (linked in python/module/CMakeLists.txt). Linking both directly embeds epmodel's
+    # object code twice, which MSVC rejects (LNK2005) since its import-lib thunks for
+    # openstudioepmodellib collide with the directly-linked definitions.
+    target_link_libraries(${python_target} PUBLIC ${${PARENT_TARGET}_depends})
     add_dependencies(${python_target} ${PARENT_TARGET})
 
     if(MSVC)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,28 +1,94 @@
 
 # Some operating systems don't like compiling a library with
 # no source files
-add_library(openstudiolib SHARED empty.cpp)
 
+if(MSVC)
+  # MSVC import libraries (and the DLL export ordinal table) are limited to 65,535 exported
+  # symbols (LNK1189). model + epmodel together export ~123,000 unique symbols, far beyond
+  # that limit, so on Windows the object libraries are split across four DLLs:
+  #
+  #                    openstudioutilitieslib
+  #                      ▲                ▲
+  #      openstudiomodellib          openstudioepmodellib
+  #                      ▲                ▲
+  #                       openstudiolib
+  #
+  # openstudiolib keeps its name and PUBLIC-links the others so that no consumer
+  # (CLI, ruby/python/csharp bindings, tests) needs any change.
+  # Each OBJECT library still lands in exactly one DLL, so the per-component
+  # openstudio_<name>_EXPORTS / <NAME>_API macros produce correct dllexport/dllimport.
+  add_library(openstudioutilitieslib SHARED empty.cpp)
+  target_link_libraries(
+   openstudioutilitieslib
+   PRIVATE
+   openstudio_utilities
+  )
 
-target_link_libraries(
- openstudiolib
- PRIVATE
- openstudio_utilities
- openstudio_airflow
- openstudio_model
- openstudio_modelica
- openstudio_energyplus
- openstudio_epmodel
- openstudio_epjson
- openstudio_alfalfa
- openstudio_measure
- openstudio_osversion
- openstudio_sdd
- openstudio_isomodel
- openstudio_gbxml
- openstudio_gltf
- openstudio_radiance
-)
+  add_library(openstudiomodellib SHARED empty.cpp)
+  target_link_libraries(
+   openstudiomodellib
+   PRIVATE
+   openstudio_model
+   openstudio_energyplus
+   PUBLIC
+   openstudioutilitieslib
+  )
+
+  add_library(openstudioepmodellib SHARED empty.cpp)
+  target_link_libraries(
+   openstudioepmodellib
+   PRIVATE
+   openstudio_epmodel
+   PUBLIC
+   openstudioutilitieslib
+  )
+
+  add_library(openstudiolib SHARED empty.cpp)
+  target_link_libraries(
+   openstudiolib
+   PRIVATE
+   openstudio_airflow
+   openstudio_modelica
+   openstudio_epjson
+   openstudio_alfalfa
+   openstudio_measure
+   openstudio_osversion
+   openstudio_sdd
+   openstudio_isomodel
+   openstudio_gbxml
+   openstudio_gltf
+   openstudio_radiance
+   PUBLIC
+   openstudiomodellib
+   openstudioepmodellib
+  )
+
+  set(openstudio_lib_targets openstudiolib openstudiomodellib openstudioepmodellib openstudioutilitieslib)
+else()
+  add_library(openstudiolib SHARED empty.cpp)
+
+  target_link_libraries(
+   openstudiolib
+   PRIVATE
+   openstudio_utilities
+   openstudio_airflow
+   openstudio_model
+   openstudio_modelica
+   openstudio_energyplus
+   openstudio_epmodel
+   openstudio_epjson
+   openstudio_alfalfa
+   openstudio_measure
+   openstudio_osversion
+   openstudio_sdd
+   openstudio_isomodel
+   openstudio_gbxml
+   openstudio_gltf
+   openstudio_radiance
+  )
+
+  set(openstudio_lib_targets openstudiolib)
+endif()
 
 target_link_libraries(
  openstudiolib
@@ -36,7 +102,9 @@ target_link_libraries(
  fmt::fmt
 )
 
-target_compile_definitions(openstudiolib INTERFACE "-DSHARED_OS_LIBS")
+foreach(_os_lib IN LISTS openstudio_lib_targets)
+  target_compile_definitions(${_os_lib} INTERFACE "-DSHARED_OS_LIBS")
+endforeach()
 
 # We cannot make the libs that make up the shared library public dependency at all, if we do
 # then we have to export and install them as well, which we probably don't want to do.
@@ -59,7 +127,7 @@ target_include_directories(
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>
   )
 
-install(TARGETS openstudiolib
+install(TARGETS ${openstudio_lib_targets}
         EXPORT openstudio
         DESTINATION ${LIB_DESTINATION_DIR}
         COMPONENT "CLI"  # CLI is no longer self-contained, it needs it

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -17,6 +17,11 @@ if(MSVC)
   # (CLI, ruby/python/csharp bindings, tests) needs any change.
   # Each OBJECT library still lands in exactly one DLL, so the per-component
   # openstudio_<name>_EXPORTS / <NAME>_API macros produce correct dllexport/dllimport.
+  #
+  # openstudio_osversion goes in openstudiomodellib (not the top-level openstudiolib)
+  # because model/Model.cpp calls osversion::VersionTranslator directly (Model::load),
+  # while osversion links openstudio_model's own dependency chain -- a genuine mutual
+  # dependency that only compiles when both land in the same DLL.
   add_library(openstudioutilitieslib SHARED empty.cpp)
   target_link_libraries(
    openstudioutilitieslib
@@ -30,6 +35,7 @@ if(MSVC)
    PRIVATE
    openstudio_model
    openstudio_energyplus
+   openstudio_osversion
    PUBLIC
    openstudioutilitieslib
   )
@@ -52,7 +58,6 @@ if(MSVC)
    openstudio_epjson
    openstudio_alfalfa
    openstudio_measure
-   openstudio_osversion
    openstudio_sdd
    openstudio_isomodel
    openstudio_gbxml

--- a/src/measure/CMakeLists.txt
+++ b/src/measure/CMakeLists.txt
@@ -46,7 +46,7 @@ CREATE_SRC_GROUPS("${${target_name}_src}")
 CREATE_SRC_GROUPS("${${target_name}_swig_src}")
 
 set(${target_name}_depends
-  openstudio_epmodel
+  openstudio_epmodel_headers
   ${openstudio_osversion_depends}
 )
 set(${target_name}_depends ${${target_name}_depends} PARENT_SCOPE)
@@ -63,7 +63,7 @@ add_dependencies(${target_name} GenerateIddFactoryRun)
 set(${target_name}_test_depends
   ${COREFOUNDATION_LIBRARY}
   openstudiolib
-  openstudio_epmodel
+  openstudio_epmodel_headers
   fmt::fmt
 )
 

--- a/src/workflow/CMakeLists.txt
+++ b/src/workflow/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(openstudio_workflow
   Timer.cpp
 )
 
-target_link_libraries(openstudio_workflow PUBLIC openstudiolib openstudio_epmodel)
+target_link_libraries(openstudio_workflow PUBLIC openstudiolib openstudio_epmodel_headers)
 
 if(BUILD_TESTING)
   set(openstudio_workflow_test_depends


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix #5631

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
