### PR TITLE
Fix #5645 - SWIG 4.4.0 breaks Python and Ruby bindings for methods taking std::vector<T> where T is only forward-declared in the defining .i module5645 swig

### DIFF
--- a/ruby/test/Issue_5645_Test.rb
+++ b/ruby/test/Issue_5645_Test.rb
@@ -1,0 +1,60 @@
+########################################################################################################################
+#  OpenStudio(R), Copyright (c) Alliance for Energy Innovation, LLC.
+#  See also https://openstudio.net/license
+########################################################################################################################
+
+require 'openstudio'
+require 'minitest/autorun'
+
+# Regression test for #5645: SWIG 4.4.0 broke methods taking a std::vector<T> parameter where T is
+# only forward-declared in the module that defines the method, and the real type (plus its
+# %template(...Vector)) lives in a separate, dependent SWIG module.
+class Issue_5645_Test < Minitest::Test
+  def test_ShadowCalculation_addShadingZoneGroup
+    model = OpenStudio::Model::Model.new
+    zone = OpenStudio::Model::ThermalZone.new(model)
+    sc = model.getShadowCalculation
+
+    zone_vector = OpenStudio::Model::ThermalZoneVector.new
+    zone_vector.push(zone)
+
+    assert(sc.addShadingZoneGroup(zone_vector))
+    zones = sc.getShadingZoneGroup(0)
+    assert_equal(1, zones.size)
+    assert_equal(zone.handle, zones[0].handle)
+  end
+
+  def test_ShadingControl_addSubSurfaces_setSubSurfaces
+    model = OpenStudio::Model::Model.new
+    blind = OpenStudio::Model::Blind.new(model)
+    shadingControl = OpenStudio::Model::ShadingControl.new(blind)
+
+    vertices1 = OpenStudio::Point3dVector.new
+    vertices1.push(OpenStudio::Point3d.new(0, 0, 1))
+    vertices1.push(OpenStudio::Point3d.new(0, 0, 0))
+    vertices1.push(OpenStudio::Point3d.new(1, 0, 0))
+    vertices1.push(OpenStudio::Point3d.new(1, 0, 1))
+    subSurface1 = OpenStudio::Model::SubSurface.new(vertices1, model)
+
+    vertices2 = OpenStudio::Point3dVector.new
+    vertices2.push(OpenStudio::Point3d.new(0, 1, 1))
+    vertices2.push(OpenStudio::Point3d.new(0, 1, 0))
+    vertices2.push(OpenStudio::Point3d.new(1, 1, 0))
+    vertices2.push(OpenStudio::Point3d.new(1, 1, 1))
+    subSurface2 = OpenStudio::Model::SubSurface.new(vertices2, model)
+
+    subSurfaces = OpenStudio::Model::SubSurfaceVector.new
+    subSurfaces.push(subSurface1)
+    subSurfaces.push(subSurface2)
+
+    assert_equal(0, shadingControl.numberofSubSurfaces)
+    assert(shadingControl.addSubSurfaces(subSurfaces))
+    assert_equal(2, shadingControl.numberofSubSurfaces)
+
+    shadingControl.removeAllSubSurfaces
+    assert_equal(0, shadingControl.numberofSubSurfaces)
+
+    assert(shadingControl.setSubSurfaces(subSurfaces))
+    assert_equal(2, shadingControl.numberofSubSurfaces)
+  end
+end

--- a/src/model/ModelGeometry.i
+++ b/src/model/ModelGeometry.i
@@ -391,6 +391,51 @@ SWIG_MODELOBJECT(ExteriorWaterEquipment, 1);
 
 #endif
 
+#if defined(SWIGPYTHON) || defined(SWIGRUBY)
+  // See ModelResources.i: SWIG >= 4.4.0 cannot resolve std::vector<SubSurface> as a parameter or
+  // return type there since SubSurface is only forward-declared in that module. Reimplement these
+  // here where SubSurface is fully known, then rebind them onto ShadingControl below.
+  %inline {
+    namespace openstudio {
+      namespace model {
+        std::vector<openstudio::model::SubSurface> getSubSurfaces(const openstudio::model::ShadingControl& sc) {
+          return sc.subSurfaces();
+        }
+        bool addSubSurfacesForShadingControl(openstudio::model::ShadingControl sc, const std::vector<openstudio::model::SubSurface>& subSurfaces) {
+          return sc.addSubSurfaces(subSurfaces);
+        }
+        bool setSubSurfacesForShadingControl(openstudio::model::ShadingControl sc, const std::vector<openstudio::model::SubSurface>& subSurfaces) {
+          return sc.setSubSurfaces(subSurfaces);
+        }
+      }
+    }
+  }
+#endif
+
+#if defined SWIGPYTHON
+  %pythoncode %{
+    def _subSurfaces(self):
+        return getSubSurfaces(self)
+    openstudiomodelresources.ShadingControl.subSurfaces = _subSurfaces
+
+    def _addSubSurfaces(self, subSurfaces):
+        return addSubSurfacesForShadingControl(self, subSurfaces)
+    openstudiomodelresources.ShadingControl.addSubSurfaces = _addSubSurfaces
+
+    def _setSubSurfaces(self, subSurfaces):
+        return setSubSurfacesForShadingControl(self, subSurfaces)
+    openstudiomodelresources.ShadingControl.setSubSurfaces = _setSubSurfaces
+  %}
+#endif
+
+#if defined SWIGRUBY
+  %init %{
+    rb_eval_string("OpenStudio::Model::ShadingControl.class_eval { define_method(:subSurfaces) { OpenStudio::Model.getSubSurfaces(self); } }");
+    rb_eval_string("OpenStudio::Model::ShadingControl.class_eval { define_method(:addSubSurfaces) { |subSurfaces| OpenStudio::Model.addSubSurfacesForShadingControl(self, subSurfaces); } }");
+    rb_eval_string("OpenStudio::Model::ShadingControl.class_eval { define_method(:setSubSurfaces) { |subSurfaces| OpenStudio::Model.setSubSurfacesForShadingControl(self, subSurfaces); } }");
+  %}
+#endif
+
 #if defined(SWIGCSHARP)
   //%pragma(csharp) imclassimports=%{
   %pragma(csharp) moduleimports=%{

--- a/src/model/ModelHVAC.i
+++ b/src/model/ModelHVAC.i
@@ -482,6 +482,43 @@ SWIG_MODELOBJECT(LoadingIndex, 1);
   } // %inline
 #endif
 
+#if defined(SWIGPYTHON) || defined(SWIGRUBY)
+  // See ModelSimulation.i: SWIG >= 4.4.0 cannot resolve std::vector<ThermalZone> as a parameter or
+  // return type there since ThermalZone is only forward-declared in that module. Reimplement both
+  // here where ThermalZone is fully known, then rebind them onto ShadowCalculation below.
+  %inline {
+    namespace openstudio {
+      namespace model {
+        std::vector<openstudio::model::ThermalZone> getShadingZoneGroup(const openstudio::model::ShadowCalculation& sc, unsigned groupIndex) {
+          return sc.getShadingZoneGroup(groupIndex);
+        }
+        bool addShadingZoneGroup(openstudio::model::ShadowCalculation sc, const std::vector<openstudio::model::ThermalZone>& thermalZones) {
+          return sc.addShadingZoneGroup(thermalZones);
+        }
+      }
+    }
+  }
+#endif
+
+#if defined SWIGPYTHON
+  %pythoncode %{
+    def _getShadingZoneGroup(self, groupIndex):
+        return getShadingZoneGroup(self, groupIndex)
+    openstudiomodelsimulation.ShadowCalculation.getShadingZoneGroup = _getShadingZoneGroup
+
+    def _addShadingZoneGroup(self, thermalZones):
+        return addShadingZoneGroup(self, thermalZones)
+    openstudiomodelsimulation.ShadowCalculation.addShadingZoneGroup = _addShadingZoneGroup
+  %}
+#endif
+
+#if defined SWIGRUBY
+  %init %{
+    rb_eval_string("OpenStudio::Model::ShadowCalculation.class_eval { define_method(:getShadingZoneGroup) { |groupIndex| OpenStudio::Model.getShadingZoneGroup(self, groupIndex); } }");
+    rb_eval_string("OpenStudio::Model::ShadowCalculation.class_eval { define_method(:addShadingZoneGroup) { |thermalZones| OpenStudio::Model.addShadingZoneGroup(self, thermalZones); } }");
+  %}
+#endif
+
 #if defined(SWIGCSHARP)
   //%pragma(csharp) imclassimports=%{
   %pragma(csharp) moduleimports=%{

--- a/src/model/ModelResources.i
+++ b/src/model/ModelResources.i
@@ -25,13 +25,10 @@
   %ignore openstudio::model::SpaceType::spaces;
   %ignore openstudio::model::SpaceLoadDefinition::instances;
   %ignore openstudio::model::ExteriorLoadDefinition::instances;
-  %ignore openstudio::model::ShadingControl::subSurfaces;
   %ignore openstudio::model::ShadingControl::subSurfaceIndex;
   %ignore openstudio::model::ShadingControl::addSubSurface;
   %ignore openstudio::model::ShadingControl::setSubSurfaceIndex;
   %ignore openstudio::model::ShadingControl::removeSubSurface(const SubSurface& subSurface); // The unsigned index overload is fine
-  %ignore openstudio::model::ShadingControl::addSubSurfaces;
-  %ignore openstudio::model::ShadingControl::setSubSurfaces;
 
   // CoilCoolingDX is defined in StraightComponent.i
   %ignore openstudio::model::CoilCoolingDXCurveFitPerformance::coilCoolingDXs;
@@ -43,6 +40,16 @@
   %ignore openstudio::model::ExternalFile::chillerElectricASHRAE205s;
 
 #endif
+
+// Note JM 2026-08-31: SWIG >= 4.4.0 cannot properly resolve std::vector<SubSurface> as a parameter
+// or return type here, because SubSurface is only forward-declared in this module: the real type
+// and its %template(SubSurfaceVector) live in ModelGeometry.i, which imports this module. This used
+// to work with SWIG 4.1.1. Ignore these here (for all languages, not just C#/Java) and
+// reimplement/rebind them in ModelGeometry.i where SubSurface is fully known.
+// See https://github.com/NatLabRockies/OpenStudio/issues/5645
+%ignore openstudio::model::ShadingControl::subSurfaces;
+%ignore openstudio::model::ShadingControl::addSubSurfaces;
+%ignore openstudio::model::ShadingControl::setSubSurfaces;
 
 #if defined(SWIGJAVA)
 %ignore openstudio::model::OpaqueMaterial::solarAbsorptance;

--- a/src/model/ModelSimulation.i
+++ b/src/model/ModelSimulation.i
@@ -28,11 +28,16 @@
   %ignore openstudio::model::WeatherFile::site;
   %ignore openstudio::model::ClimateZones::site;
 
-  // Note JM 2020-03-11: Ignoring this, will reimplement later in ModelHVAC.i using partial classes
-  %ignore openstudio::model::ShadowCalculation::addShadingZoneGroup;
-  %ignore openstudio::model::ShadowCalculation::getShadingZoneGroup;
-
 #endif
+
+// Note JM 2026-08-31: SWIG >= 4.4.0 cannot properly resolve std::vector<ThermalZone> as a parameter
+// or return type here, because ThermalZone is only forward-declared in this module: the real type
+// and its %template(ThermalZoneVector) live in ModelHVAC.i, which imports this module. This used to
+// work with SWIG 4.1.1. Ignore both here (for all languages, not just C#) and reimplement/rebind them
+// in ModelHVAC.i where ThermalZone is fully known.
+// See https://github.com/NatLabRockies/OpenStudio/issues/5645
+%ignore openstudio::model::ShadowCalculation::addShadingZoneGroup;
+%ignore openstudio::model::ShadowCalculation::getShadingZoneGroup;
 
 #if defined SWIGPYTHON
   %pythoncode %{


### PR DESCRIPTION
Pull request overview
---------------------

 - Fix the item 3 of #5645

Ideally a newer SWIG version will fix it, but for now the workaround is to do the same as we do for C#: ignore, and reimplement later.

- https://github.com/swig/swig/issues/3553
    - PR: https://github.com/swig/swig/pull/3554  
    

With this, OpenStudio-resources tests shadowcalculation.{py,rb}, shadingcontrol_singlezone.{py,rb} now work.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Model API Changes / Additions
 - [ ] Any new or modified fields have been implemented in the EnergyPlus ForwardTranslator (and ReverseTranslator as appropriate)
 - [ ] Model API methods are tested (in `src/model/test`)
 - [ ] EnergyPlus ForwardTranslator Tests (in `src/energyplus/Test`)
 - [ ] If a new object or method, added a test in NREL/OpenStudio-resources: Add Link
 - [ ] If needed, added VersionTranslation rules for the objects (`src/osversion/VersionTranslator.cpp`)
 - [ ] Verified that C# bindings built fine on Windows, partial classes used as needed, etc.
 - [ ] All new and existing tests passes
 - [ ] If methods have been deprecated, update rest of code to use the new methods

**Labels:**

 - [ ] If change to an IDD file, add the label `IDDChange`
 - [ ] If breaking existing API, add the label `APIChange`
 - [ ] If deemed ready, add label `Pull Request - Ready for CI` so that CI builds your PR

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a Code Review on GitHub
 - [ ] Code Style, strip trailing whitespace, etc.
 - [ ] All related changes have been implemented: model changes, model tests, FT changes, FT tests, VersionTranslation, OS App
 - [ ] Labeling is ok
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
